### PR TITLE
Remove garbage chars in the ruby example code

### DIFF
--- a/source/version2/client.html.slim
+++ b/source/version2/client.html.slim
@@ -68,7 +68,7 @@ markdown:
   But the client really exists to send SOAP messages, so let's do that.
 
   ``` ruby
-  response = dnnad jksdjfds jsdfjkb jkbsf djbkfs client.call(:authenticate, message: { username: "luke", password: "secret" })
+  response = client.call(:authenticate, message: { username: "luke", password: "secret" })
   ```
 
   If you used Savon before, this should also look familiar to you. But in contrast to the old client,


### PR DESCRIPTION
I saw this typo on the official website:

http://savonrb.com/version2/client.html
