### PR TITLE
The any-message matcher needs the symbol :any

### DIFF
--- a/source/version2/testing.html.slim
+++ b/source/version2/testing.html.slim
@@ -85,7 +85,7 @@ markdown:
   This is possible because Savon mocks the request as late as possible to ensure everything works as expected
   in your integration tests.
 
-  If you're trying to "stub" a request, you can pass `message: any` to the `#with` method to accept any message. You still need to call the
+  If you're trying to "stub" a request, you can pass `message: :any` to the `#with` method to accept any message. You still need to call the
   `#returns` method to return a response that Savon can work with.
 
   ``` ruby


### PR DESCRIPTION
Adding a missing `:`.
