### PR TITLE
bugfixes for gh pages hosting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,0 @@
-desc 'Start development server'
-task :server do
-  system 'bundle exec middleman server'
-end

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,8 +9,8 @@
   <meta content="BSMPrQXuQ6oR3VoyILGebkF0glrpfN58u5jHQap0r3Y" name="google-site-verification" />
   <title>{{ page.title }} - Savon (Heavy Metal SOAP Client)</title>
   <script src="https://kit.fontawesome.com/b687de9781.js" crossorigin="anonymous"></script>
-  <link href="{{site.url}}/assets/stylesheets/highlight.css" rel="stylesheet" />
-  <link href="{{site.url}}/assets/stylesheets/screen.css?mtime={{site.time | date: '%s' }}" rel="stylesheet" />
+  <link href="/assets/stylesheets/highlight.css" rel="stylesheet" />
+  <link href="/assets/stylesheets/screen.css?mtime={{site.time | date: '%s' }}" rel="stylesheet" />
 </head>
 
 <body>


### PR DESCRIPTION
Followup to #39 and #40 

* remove unused Rakefile
* remove hardcoded absolute reference to stylesheets, so that they dont depend on the URL being on a specific domain

This will allow the stylesheets to actually load.